### PR TITLE
Remove new line symbols

### DIFF
--- a/frida/mqttListen.js
+++ b/frida/mqttListen.js
@@ -64,13 +64,15 @@ Java.perform(function () {
     });
     const RawMqttHandler = Java.use(MESSAGE_ENCODER_SEND);
     RawMqttHandler.A00.implementation = function (thisObj, messageEncoder, message) {
-        console.log('\n\nSTART');
+        console.log('');
+        console.log('START');
         logOut = true;
         const res = this.A00(thisObj, messageEncoder, message);
         logOut = false;
         console.log(packetWriter.join(''));
         packetWriter = [];
-        console.log('END\n\n');
+        console.log('END');
+        console.log('');
         return res;
     }
 


### PR DESCRIPTION
Using "\n" produces the following error on my side:

```
Traceback (most recent call last):
  File "C:\Users\Enrique\Desktop\A\script.py", line 99, in <module>
    script = session.create_script(js)
  File "C:\Program Files (x86)\Python39-32\lib\site-packages\frida\core.py", line 26, in wrapper
    return f(*args, **kwargs)
  File "C:\Program Files (x86)\Python39-32\lib\site-packages\frida\core.py", line 204, in create_script
    return Script(self._impl.create_script(*args, **kwargs))
frida.InvalidArgumentError: script(line 44): SyntaxError: unexpected end of string
```

I'm using Frida v14.2.12. This pull request fixes the issue.